### PR TITLE
modified:   _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ email: ianiat11@gmail.com
 description: Where I write things...
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
-github_username:  jekyll
+github_username:  it176131
 
 # Build settings
 theme: minima


### PR DESCRIPTION
	- Fixed github username link. Used to say "jekyll" -> changed to "it176131".