### PR TITLE
Untracking image type files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.png filter=lfs diff=lfs merge=lfs -text
-*.jpg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
modified:   .gitattributes
	- Removed tracking of JPG and PNG files as GitHub Pages won't display images.