### PR TITLE
modified:   _posts/2024-07-10-til-typer.md

### DIFF
--- a/_posts/2024-07-10-til-typer.md
+++ b/_posts/2024-07-10-til-typer.md
@@ -283,7 +283,7 @@ def make_test_graph(ctx: typer.Context) -> None:
 runner = CliRunner()
 
 
-def test_get_descendants(ctx: typer.Context):
+def test_get_descendants() -> None:
     app.callback()(make_test_graph)  # Override the digraph here.
     command = "get-descendants"
     args = [command, "0"]


### PR DESCRIPTION
	- Removed `ctx` parameter from test :callable:`test_get_descendants` and added return type hint.